### PR TITLE
:sparkles: feat: 패딩 박스 컴포넌트 추가

### DIFF
--- a/app/editTemplate/components/DraggableArea/TextBox.tsx
+++ b/app/editTemplate/components/DraggableArea/TextBox.tsx
@@ -5,7 +5,7 @@ import { Draggable } from 'react-beautiful-dnd';
 import { BOX_PROPERTY, BoxType } from '../../../../constants/box';
 import { useConfig } from '@/store/slice/configSlice';
 import Image from 'next/image';
-import { DNDBoxState, removeBox, useDNDBox } from '@/store/slice/DNDBoxSlice';
+import { DNDBoxState, removeBox, updateSelected, useDNDBox } from '@/store/slice/DNDBoxSlice';
 import DeleteButton from '@/components/DeleteButton';
 
 type Props = {
@@ -16,7 +16,6 @@ type Props = {
 	areaType: keyof Pick<DNDBoxState, 'faqArea' | 'priceCardArea' | 'tableArea'>;
 	role: BoxType;
 	content: string;
-	onClick: (id: string) => void;
 };
 
 export default function TextBox({
@@ -27,9 +26,8 @@ export default function TextBox({
 	role,
 	content,
 	areaType,
-	onClick,
 }: Props) {
-	const { divClassName, inputClassName } = BOX_PROPERTY[role];
+	const { divClassName } = BOX_PROPERTY[role];
 	const { dispatch } = useDNDBox();
 
 	const { configState } = useConfig();
@@ -41,7 +39,7 @@ export default function TextBox({
 		<Draggable draggableId={id} index={index}>
 			{(provided) => (
 				<div
-					onClick={() => onClick(id)}
+				onClick={() => dispatch(updateSelected({ id, areaType }))}
 					{...provided.draggableProps}
 					ref={provided.innerRef}
 					className={`${
@@ -67,7 +65,7 @@ export default function TextBox({
 					</div>
 					<DeleteButton onClick={handleRemove} />
 					<input
-						className={` ${inputClassName} text-center font-bold focus:outline-none disabled:bg-transparent`}
+						className='font-bold text-center focus:outline-none disabled:bg-transparent'
 						defaultValue={content}
 						disabled={isPreview}
 						type="text"

--- a/app/editTemplate/components/DraggableArea/index.tsx
+++ b/app/editTemplate/components/DraggableArea/index.tsx
@@ -2,16 +2,9 @@
 
 import React from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
-// import StrictModeDroppable from '@/utils/StrictModeDroppable';
 import TextBox from './TextBox';
 import PaddingBox from './PaddingBox';
-import {
-	DNDBoxState,
-	addBox,
-	updateOrder,
-	updateSelected,
-	useDNDBox,
-} from '@/store/slice/DNDBoxSlice';
+import { DNDBoxState, updateOrder, useDNDBox } from '@/store/slice/DNDBoxSlice';
 import { StrictModeDroppable } from '@/app/helpers/StrictModeDroppable';
 
 export default function DraggableArea({
@@ -37,10 +30,6 @@ export default function DraggableArea({
 		dispatch(updateOrder({ areaType, newList: updatedList }));
 	};
 
-	const handleSelect = (id: string) => {
-		dispatch(updateSelected({ id, areaType }));
-	};
-	
 	return (
 		<div>
 			<DragDropContext onDragEnd={handleOnDragEnd}>
@@ -53,7 +42,6 @@ export default function DraggableArea({
 										key={item.id}
 										index={index}
 										{...item}
-										onClick={handleSelect}
 										areaType={areaType}
 									/>
 								) : (
@@ -61,7 +49,6 @@ export default function DraggableArea({
 										key={item.id}
 										{...item}
 										placeholder={item.placeholder || ''}
-										onClick={handleSelect}
 										index={index}
 										areaType={areaType}
 										// inputRef={addRef(index, React.createRef())}

--- a/app/editTemplate/page.tsx
+++ b/app/editTemplate/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
 	PriceCard,
 	setPriceCard,
@@ -26,6 +26,9 @@ import TableContainer from './components/Table/TableContainer';
 import { useModal } from '@/store/slice/modalSlice';
 import Header from '@/components/header/Header';
 import TemplateHeader from '@/components/header/TemplateHeader';
+import PaddingBox from './components/DraggableArea/PaddingBox';
+import ResizablePaddingWithHandle from '@/components/ResizablePaddingWithHandle';
+import { updateHeight, useDNDBox } from '@/store/slice/DNDBoxSlice';
 
 export default function EditTemplate() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -110,6 +113,19 @@ export default function EditTemplate() {
 	const { configState } = useConfig();
 	const { isPreview } = configState;
 
+	const { boxState, dispatch: dndDispatch } = useDNDBox();
+
+	const handleHeightUpdate = (index: number, height: number) => {
+		dndDispatch(
+			updateHeight({
+				areaType: 'outerPaddings',
+				index,
+				content: height.toString(),
+			}),
+		);
+
+	};
+
 	const {} = useModal();
 	return (
 		<>
@@ -126,7 +142,19 @@ export default function EditTemplate() {
 					<DiscountOptionBox />
 					<PriceCardBox />
 				</section>
+				<ResizablePaddingWithHandle
+					type="outer"
+					onAction={(height) => {
+						handleHeightUpdate(0, height);
+					}}
+				/>
 				<TableContainer />
+				<ResizablePaddingWithHandle
+					type="outer"
+					onAction={(height) => {
+						handleHeightUpdate(1, height);
+					}}
+				/>
 				<section
 					className={`${
 						isPreview ? 'editable-outer-preview' : 'editable-outer '

--- a/app/priceCard/components/DiscountOptionBox/DiscountOptionBox.tsx
+++ b/app/priceCard/components/DiscountOptionBox/DiscountOptionBox.tsx
@@ -1,13 +1,23 @@
 'use client';
 import React from 'react';
 import DiscountOptionSection from './DiscountOptionSection/DiscountOptionSection';
-import PaddingBox from './PaddingBox';
+import ResizablePaddingWithHandle from '../../../../components/ResizablePaddingWithHandle';
+
 
 function DiscountOptionBox() {
+	
+  const handleHeightUpdate = (height: number) => {
+		// const { updateCardPaddingHeight } = useCard()
+		// dispatch(updateCardPaddingHeight({ height }))
+	}
+
 	return (
 		<div>
 			<DiscountOptionSection />
-			<PaddingBox />
+			<ResizablePaddingWithHandle
+				type="inner"
+				onAction={handleHeightUpdate}
+			/>
 		</div>
 	);
 }

--- a/app/priceCard/components/DiscountOptionBox/PaddingBox.tsx
+++ b/app/priceCard/components/DiscountOptionBox/PaddingBox.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function PaddingBox() {
-	return <div>PaddingBox</div>;
-}
-
-export default PaddingBox;

--- a/components/ResizablePaddingBox.tsx
+++ b/components/ResizablePaddingBox.tsx
@@ -1,0 +1,70 @@
+import { BOX_PROPERTY, PaddingType } from '@/constants/box';
+import { useConfig } from '@/store/slice/configSlice';
+import React, { useEffect, useRef, useState } from 'react';
+import { ResizableBox, ResizeCallbackData } from 'react-resizable';
+
+type PropsType = {
+	type: PaddingType;
+	heightState: [number, React.Dispatch<React.SetStateAction<number>>];
+	onAction: (height: number) => void;
+};
+
+export default function ResizablePaddingBox({
+	type,
+	heightState,
+	onAction,
+}: PropsType) {
+	const heightRange = BOX_PROPERTY.PADDING[type];
+	const { configState } = useConfig();
+	const { isPreview } = configState;
+
+	const [width, setWidth] = useState<number>(0);
+
+	const wrapperRef = useRef<HTMLDivElement>(null);
+
+	const handleResize = (
+		e: React.SyntheticEvent,
+		{ size }: ResizeCallbackData,
+	) => {
+		const flooredHeight = Math.floor(size.height);
+		onAction(flooredHeight);
+	};
+
+	const handleDisplayHeight = (
+		e: React.SyntheticEvent,
+		{ size }: ResizeCallbackData,
+	) => {
+		if (size.height !== heightState[0]) {
+			heightState[1](size.height);
+		}
+	};
+
+	useEffect(() => {
+		const handleWindowResize = () => {
+			if (wrapperRef.current) {
+				setWidth(wrapperRef.current.getBoundingClientRect().width);
+			}
+		};
+		handleWindowResize();
+		window.addEventListener('resize', handleWindowResize);
+
+		return () => {
+			window.removeEventListener('resize', handleWindowResize);
+		};
+	}, []);
+	return (
+		<div ref={wrapperRef}>
+			<ResizableBox
+				height={heightState[0]}
+				lockAspectRatio={true}
+				onResizeStop={handleResize}
+				minConstraints={[width, heightRange.minHeight]}
+				maxConstraints={[width, heightRange.maxHeight]}
+				width={width}
+				onResize={handleDisplayHeight}
+				resizeHandles={isPreview ? [] : ['s']}
+				handleSize={[10, 10]}
+			></ResizableBox>
+		</div>
+	);
+}

--- a/components/ResizablePaddingWithHandle.tsx
+++ b/components/ResizablePaddingWithHandle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import OuterPaddingBox from '@/components/ResizablePaddingBox';
+import { BOX_PROPERTY, PaddingType } from '@/constants/box';
+import { useConfig } from '@/store/slice/configSlice';
+import Image from 'next/image';
+import React, { useState } from 'react';
+
+type PropsType = {
+	type: PaddingType
+	onAction: (height: number) => void;
+};
+
+function ResizablePaddingWithHandle({ onAction, type }: PropsType) {
+	const { configState } = useConfig();
+	const { isPreview } = configState
+	const { minHeight } = BOX_PROPERTY.PADDING[type]
+
+	const heightState = useState<number>(minHeight);
+	return (
+		<div className="relative w-full border-2 border-transparent group hover:border-black">
+			<div
+				className={`draggable-handle flex flex-col items-center gap-1 ${
+					!isPreview
+						? 'group-hover:-translate-x-11 group-hover:opacity-100'
+						: ''
+				} `}
+			>
+				<div className="relative">
+					<div className="absolute -top-5 right-[50%] w-9 translate-x-[50%] text-center text-xs shadow-md">
+						{Math.floor(heightState[0])}px
+					</div>
+					<Image
+						width={24}
+						height={24}
+						src={'/icons/drag_vert.svg'}
+						alt="drag handle svg image"
+					/>
+				</div>
+			</div>
+
+			<OuterPaddingBox
+				type={type}
+				heightState={heightState}
+				onAction={onAction}
+			/>
+		</div>
+	);
+}
+
+export default ResizablePaddingWithHandle;

--- a/constants/box.ts
+++ b/constants/box.ts
@@ -1,33 +1,40 @@
 import { v4 as uuid } from 'uuid';
-
 export type BoxType = 'TITLE' | 'SUBTITLE' | 'TEXT' | 'PADDING';
+export type PaddingType = 'outer' | 'inner';
 
+export type PaddingHeightRange = {
+	[key in PaddingType]: {
+		minHeight: number;
+		maxHeight: number;
+	}
+};
 export const BOX_PROPERTY: {
 	[key in BoxType]: {
-		divClassName: string
-		inputClassName: string
-		minHeight?:number
-		maxHeight?:number
-	};
+		divClassName: string;
+	} & (key extends 'PADDING'
+		? PaddingHeightRange
+		: {});
 } = {
 	TITLE: {
-		divClassName: "draggable-title",
-		inputClassName: "draggable-title"
+		divClassName: 'draggable-title',
 	},
 	SUBTITLE: {
-		divClassName: "draggable-subtitle",
-		inputClassName: "draggable-subtitle"
+		divClassName: 'draggable-subtitle',
 	},
-	TEXT:{
-		divClassName: "draggable-text",
-		inputClassName: "draggable-text"
+	TEXT: {
+		divClassName: 'draggable-text',
 	},
 	PADDING: {
-		divClassName: "draggable-padding",
-		inputClassName: "",
-		minHeight: 10,
-		maxHeight: 200
-	}
+		divClassName: 'draggable-padding',
+		outer: {
+			minHeight: 100,
+			maxHeight: 500,
+		},
+		inner: {
+			minHeight: 10,
+			maxHeight: 200,
+		},
+	},
 };
 
 export interface DraggableBox {
@@ -35,7 +42,7 @@ export interface DraggableBox {
 	placeholder?: string;
 	role: BoxType;
 	content: string;
-	isSelected: boolean
+	isSelected: boolean;
 }
 
 export function generateDraggableBoxProp({
@@ -46,33 +53,33 @@ export function generateDraggableBoxProp({
 		case 'TITLE':
 			return {
 				id: uuid(),
-				placeholder: placeholder ?? "타이틀",
+				placeholder: placeholder ?? '타이틀',
 				role: 'TITLE' as BoxType,
 				content: '',
-				isSelected: false
+				isSelected: false,
 			};
 		case 'SUBTITLE':
 			return {
 				id: uuid(),
-				placeholder: placeholder ?? "서브 타이틀",
+				placeholder: placeholder ?? '서브 타이틀',
 				role: 'SUBTITLE' as BoxType,
 				content: '',
-				isSelected: false
+				isSelected: false,
 			};
 		case 'TEXT':
 			return {
 				id: uuid(),
-				placeholder: placeholder ?? "텍스트",
+				placeholder: placeholder ?? '텍스트',
 				role: 'TEXT' as BoxType,
 				content: '',
-				isSelected: false
+				isSelected: false,
 			};
 		case 'PADDING':
 			return {
 				id: uuid(),
 				role: 'PADDING' as BoxType,
 				content: '10',
-				isSelected: false
+				isSelected: false,
 			};
 
 		default:

--- a/store/slice/DNDBoxSlice.tsx
+++ b/store/slice/DNDBoxSlice.tsx
@@ -12,6 +12,7 @@ export type DNDBoxState = {
 	priceCardArea: DraggableBox[];
 	tableArea: DraggableBox[];
 	faqArea: DraggableBox[];
+	outerPaddings: string []
 	selectedBox: DraggableBox | null;
 	targetArea:
 		| keyof Pick<DNDBoxState, 'faqArea' | 'tableArea' | 'priceCardArea'>
@@ -19,7 +20,7 @@ export type DNDBoxState = {
 };
 
 type DNDBoxPayload = {
-	areaType: keyof Pick<DNDBoxState, 'faqArea' | 'tableArea' | 'priceCardArea'>
+	areaType: keyof Pick<DNDBoxState, 'faqArea' | 'tableArea' | 'priceCardArea' | 'outerPaddings'>
 	newList: DraggableBox[];
 	boxType: BoxType;
 	id: string;
@@ -45,6 +46,7 @@ const initialState: DNDBoxState = {
 	}),
 	selectedBox: null,
 	targetArea: null,
+	outerPaddings: ['100', '100']
 };
 
 export const DNDBoxSlice = createSlice({
@@ -60,9 +62,8 @@ export const DNDBoxSlice = createSlice({
 		},
 		addBox: (
 			state: DNDBoxState,
-			action: PayloadAction<Pick<DNDBoxPayload, 'boxType'>>,
+			action: PayloadAction<Pick<DNDBoxPayload, 'boxType'>>
 		) => {
-			// @TODO modal 띄워야함
 			if (state.selectedBox === null) return;
 			const { boxType } = action.payload;
 			if (state.targetArea === null) return
@@ -86,6 +87,7 @@ export const DNDBoxSlice = createSlice({
 			action: PayloadAction<Pick<DNDBoxPayload, 'id' | 'areaType'>>,
 		) => {
 			const { id, areaType } = action.payload;
+			if (areaType === 'outerPaddings') return
 			if (state[areaType].length <= 1) return
 			const newList = state[areaType].filter((box) => box.id !== id) 
 			return { ...state, [areaType]: newList };
@@ -95,8 +97,11 @@ export const DNDBoxSlice = createSlice({
 			action: PayloadAction<Pick<DNDBoxPayload, 'index' | 'areaType' | 'content'>>,
 		) => {
 			const { index, areaType, content } = action.payload;
+			if (areaType === 'outerPaddings') {
+				state.outerPaddings[index] = content
+				return state
+			}
 			state[areaType][index].content = content
-			console.log(current(state))
 			return state
 		},
 		updateSelected: (
@@ -105,7 +110,7 @@ export const DNDBoxSlice = createSlice({
 		) => {
 			const { id, areaType } = action.payload;
 
-
+			if (areaType === 'outerPaddings') return
 			if (state.targetArea !== areaType && state.targetArea !== null) {
 		
 


### PR DESCRIPTION
### 변경 사항
- 🚀  이 PR에서 변경한 내용을 나열하세요.
#### 패딩 박스 컴포넌트와 타입 추가 (외부, 내부)
- 🔧  작업한 내용 중에서 기능 개선, 버그 수정 등을 나열하세요.
#### 이제 패딩 박스 컴포넌트가 재사용 가능합니다.
- ResizablePaddingBox: props로 외부인지 내부인지 판별하는 type, 높이를 동기적으로 받는 heightState: useState<number>, 그리고 높이 값을 dispatch 할 수 있도록 onAction(height: number) => void를 받습니다. 
- ResizablePaddingWithHandle: props로 type, onAction만 받고, 요소 호버시 좌측에 아이콘과 현재 높이값을 표시해주는 텍스트박스가 나타납니다. 
- 🗑️  삭제한 코드, 파일 등을 나열하세요.

### 관련 이슈
- 🔍  이 PR로 해결된 관련 이슈 또는 JIRA 티켓을 나열하세요.

### 스크린샷 (해당하는 경우):
- 📷  관련 스크린샷을 삽입하세요.

### 추가 사항
- ℹ️  관련된 추가 정보를 추가하세요.

### 체크리스트
- [x] ✅  변경 사항을 로컬에서 테스트했습니다.
