### PR TITLE
로그인/로그아웃 기능 구현

### DIFF
--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -16,7 +16,7 @@ export const login = async (code: string) => {
 
 		const authorizationToken =
 			res.headers.get('authorization')?.slice('bearer '.length) || '';
-		document.cookie = `authorizationToken=${authorizationToken}; path=/; max-age=3600; sameSite=Strict`;
+		document.cookie = `authorizationToken=${authorizationToken}; path=/; max-age=36000; sameSite=Strict`;
 
 		return res.json();
 	} catch (err) {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -14,6 +14,17 @@ const handler = NextAuth({
 			},
 		}),
 	],
+	callbacks: {
+		async redirect({ url, baseUrl }) {
+			if (url.startsWith('/')) {
+				return `${baseUrl}${url}`;
+			} else if (new URL(url).origin === baseUrl) {
+				return url;
+			}
+
+			return baseUrl;
+		},
+	},
 });
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
1. 헤더에서 로그인 버튼 클릭 시, 카카오 로그인 페이지로 이동후 로그인 및 회원가입 완료시 메인 페이지로 복귀

2. 로그인 및 회원가입을 진행하지 않은 상태에서 다른 페이지로 이동할수 없게 설정함

3. 로그인 시 이메일 정보는 로컬 스토리지에 저장되며 로그아웃 클릭시 로컬 스토리지 데이터를 제거한다.

# Pull Request(PR) 템플릿!

### 변경 사항
- 🚀  이 PR에서 변경한 내용을 나열하세요.
- 🔧  작업한 내용 중에서 기능 개선, 버그 수정 등을 나열하세요.
- 🗑️  삭제한 코드, 파일 등을 나열하세요.

### 관련 이슈
- 🔍  이 PR로 해결된 관련 이슈 또는 JIRA 티켓을 나열하세요.

### 스크린샷 (해당하는 경우):
- 📷  관련 스크린샷을 삽입하세요.

### 추가 사항
![GOMCAM 20230629_0036260295](https://github.com/PRIETAG/PRIETAG_FE/assets/56331400/48c4871b-161e-4521-ad97-1a1d514a2d08)

- ℹ️  관련된 추가 정보를 추가하세요.

### 체크리스트
- [x] ✅  변경 사항을 로컬에서 테스트했습니다.
- [x] 📝  새로 추가하거나 수정한 코드에 적절한 문서를 추가했습니다.
- [x] 🧪  코드가 프로젝트의 기존 코드 표준을 충족시키는지 확인했습니다.
- [ ] ✔️  기존의 테스트 스위트를 실행하여 모든 테스트가 여전히 통과되는지 확인했습니다.
- [ ] 👀  이 PR에 리뷰어를 할당했습니다.